### PR TITLE
Add option to post data to URL

### DIFF
--- a/carbon/app.py
+++ b/carbon/app.py
@@ -45,4 +45,4 @@ class PersonFeed(object):
         add_child(record, 'field', person['KRB_NAME'], name='[Username]')
 
     def bytes(self):
-        return ET.tostring(self._root, encoding="UTF-8")
+        return ET.tostring(self._root, encoding="UTF-8", xml_declaration=True)

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import click
+import requests
 
 from carbon import engine, people, PersonFeed
 
@@ -13,9 +14,15 @@ def main():
 
 @main.command()
 @click.option('--db', default='sqlite:///carbon.db')
-def load(db):
+@click.option('--url')
+def load(db, url):
     engine.configure(db)
     feed = PersonFeed()
     for person in people():
         feed.add(person)
-    click.echo(feed.bytes())
+    if url is not None:
+        headers = {'Content-type': 'application/xml; charset=UTF-8'}
+        r = requests.post(url, data=feed.bytes(), headers=headers)
+        r.raise_for_status()
+    else:
+        click.echo(feed.bytes())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==5.1
 lxml==3.5.0
+requests==2.8.1
 SQLAlchemy==1.0.9
 wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'click',
+        'lxml',
+        'requests',
         'SQLAlchemy',
     ],
     entry_points={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,25 @@ def load_data():
         s.execute(persons.delete())
         s.execute(persons.insert(), [
             {'MIT_ID': '123456', 'KRB_NAME': 'foobar'},
-            {'MIT_ID': '098754', 'KRB_NAME': 'foobaz'}
+            {'MIT_ID': '098754', 'KRB_NAME': u'Þorgerðr Hǫlgabrúðr'}
         ])
     yield
     with session() as s:
         s.execute(persons.delete())
+
+
+@pytest.fixture
+def xml_data(E):
+    return E.records(
+        E.record(
+            E.field('123456', name='[Proprietary_ID]'),
+            E.field('foobar', name='[Username]')
+        ),
+        E.record(
+            E.field('098754', name='[Proprietary_ID]'),
+            E.field(u'Þorgerðr Hǫlgabrúðr', name='[Username]')
+        )
+    )
 
 
 @pytest.fixture

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ def test_people_generates_people():
     person = next(peeps)
     assert person['KRB_NAME'] == 'foobar'
     person = next(peeps)
-    assert person['KRB_NAME'] == 'foobaz'
+    assert person['KRB_NAME'] == u'Þorgerðr Hǫlgabrúðr'
 
 
 def test_add_child_adds_child_element(E):
@@ -42,4 +42,18 @@ def test_person_feed_adds_person(E):
     )
     p = PersonFeed()
     p.add({'MIT_ID': '1234', 'KRB_NAME': 'foobar'})
-    assert p.bytes() == ET.tostring(xml)
+    assert p.bytes() == ET.tostring(xml, encoding="UTF-8",
+                                    xml_declaration=True)
+
+
+def test_person_feed_uses_utf8_encoding(E):
+    xml = E.records(
+        E.record(
+            E.field('1234', {'name': '[Proprietary_ID]'}),
+            E.field(u'Þorgerðr Hǫlgabrúðr', {'name': '[Username]'})
+        )
+    )
+    p = PersonFeed()
+    p.add({'MIT_ID': '1234', 'KRB_NAME': u'Þorgerðr Hǫlgabrúðr'})
+    assert p.bytes() == ET.tostring(xml, encoding="UTF-8",
+                                    xml_declaration=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from click.testing import CliRunner
 from lxml import etree as ET
 import pytest
+import requests_mock
 
 from carbon.cli import main
 
@@ -16,18 +17,20 @@ def runner():
     return CliRunner()
 
 
-def test_load_returns_people(runner, E):
-    xml = E.records(
-        E.record(
-            E.field('123456', name='[Proprietary_ID]'),
-            E.field('foobar', name='[Username]')
-        ),
-        E.record(
-            E.field('098754', name='[Proprietary_ID]'),
-            E.field('foobaz', name='[Username]')
-        )
-    )
+def test_load_returns_people(runner, E, xml_data):
     res = runner.invoke(main, ['load', '--db',
                         'sqlite:///tests/db/test.db'])
     assert res.exit_code == 0
-    assert res.output.encode('utf-8') == ET.tostring(xml) + b'\n'
+    assert res.output.encode('utf-8') == \
+        ET.tostring(xml_data, encoding="UTF-8", xml_declaration=True) + b'\n'
+
+
+def test_load_posts_to_url(runner, E, xml_data):
+    with requests_mock.Mocker() as m:
+        m.post('http://example.com', text='congrats')
+        runner.invoke(main, ['load', '--db', 'sqlite:///tests/db/test.db',
+                             '--url', 'http://example.com'])
+        req = m.request_history[0]
+        assert req.text.encode('utf-8') == ET.tostring(xml_data,
+                                                       encoding="UTF-8",
+                                                       xml_declaration=True)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands = py.test {posargs:--tb=short}
 deps =
     pytest
     mock
+    requests-mock
     -r{toxinidir}/requirements.txt
 
 [testenv:clean]


### PR DESCRIPTION
This adds a command line option to POST the XML feed to a URL. This
also ensures that UTF-8 encoding is used throughout when serializing
the XML.