### PR TITLE
Use streaming XML generator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 carbon
 ======
 
-Carbon is a tool for loading people into Symplectic Elements.
+Carbon is a tool for generating a feed of people that can be loaded into Symplectic Elements.
 
 
 Usage
@@ -15,6 +15,6 @@ View the help menu for the `carbon` command::
 
     $ carbon --help
 
-View the help menu for the `load` subcommand::
+View the help menu for the `feed` subcommand::
 
-    $ carbon load --help
+    $ carbon feed --help

--- a/carbon/__init__.py
+++ b/carbon/__init__.py
@@ -8,5 +8,5 @@
 
 __version__ = '0.0.1'
 
-from .app import people, PersonFeed
+from .app import people, person_feed
 from .db import engine, session

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click==5.1
 lxml==3.5.0
-requests==2.8.1
 SQLAlchemy==1.0.9
 wheel==0.24.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from io import BytesIO
 
 from lxml import etree as ET
 import pytest
 
 from carbon import people
-from carbon.app import PersonFeed, ns, NSMAP, add_child, initials
+from carbon.app import person_feed, ns, NSMAP, add_child, initials
 
 
 pytestmark = pytest.mark.usefixtures('load_data')
@@ -42,21 +43,26 @@ def test_add_child_adds_child_element(E):
 
 
 def test_person_feed_uses_namespace():
-    p = PersonFeed()
-    assert p._root.tag == "{http://www.symplectic.co.uk/hrimporter}records"
+    b = BytesIO()
+    with person_feed(b):
+        pass
+    root = ET.fromstring(b.getvalue())
+    assert root.tag == "{http://www.symplectic.co.uk/hrimporter}records"
 
 
 def test_person_feed_adds_person(records, xml_records, E):
+    b = BytesIO()
     xml = E.records(xml_records[0])
-    p = PersonFeed()
-    p.add(records[0])
-    assert p.bytes() == ET.tostring(xml, encoding="UTF-8",
-                                    xml_declaration=True)
+    with person_feed(b) as f:
+        f(records[0])
+    assert b.getvalue() == ET.tostring(xml, encoding="UTF-8",
+                                       xml_declaration=True)
 
 
 def test_person_feed_uses_utf8_encoding(records, xml_records, E):
+    b = BytesIO()
     xml = E.records(xml_records[1])
-    p = PersonFeed()
-    p.add(records[1])
-    assert p.bytes() == ET.tostring(xml, encoding="UTF-8",
-                                    xml_declaration=True)
+    with person_feed(b) as f:
+        f(records[1])
+    assert b.getvalue() == ET.tostring(xml, encoding="UTF-8",
+                                       xml_declaration=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from io import BytesIO
 
 from click.testing import CliRunner
 from lxml import etree as ET
 import pytest
-import requests_mock
 
 from carbon.cli import main
 
@@ -17,19 +17,9 @@ def runner():
     return CliRunner()
 
 
-def test_load_returns_people(runner, E, xml_data):
-    res = runner.invoke(main, ['load', 'sqlite://'])
+def test_feed_returns_people(runner, E, xml_data):
+    b = BytesIO()
+    res = runner.invoke(main, ['feed', '-o', b, 'sqlite://'])
     assert res.exit_code == 0
-    assert res.output.encode('utf-8') == \
-        ET.tostring(xml_data, encoding="UTF-8", xml_declaration=True) + b'\n'
-
-
-def test_load_posts_to_url(runner, E, xml_data):
-    with requests_mock.Mocker() as m:
-        m.post('http://example.com', text='congrats')
-        runner.invoke(main, ['load', 'sqlite://', '--url',
-                             'http://example.com'])
-        req = m.request_history[0]
-        assert req.text.encode('utf-8') == ET.tostring(xml_data,
-                                                       encoding="UTF-8",
-                                                       xml_declaration=True)
+    assert b.getvalue() == \
+        ET.tostring(xml_data, encoding="UTF-8", xml_declaration=True)


### PR DESCRIPTION
This changes the XML generation to stream the output rather than
building the feed entirely in memory first. This also removes the
functionality to POST the feed. Since the feed can be saved to a
file or piped elsewhere, other tools, such as curl, can cover this.