### PR TITLE
Add support for running as AWS Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build/
 dist/
 tests/db/
+.pytest_cache

--- a/carbon/app.py
+++ b/carbon/app.py
@@ -306,7 +306,7 @@ class Config(dict):
         return cfg
 
 
-class Lambda:
+class FTPFeeder:
     def __init__(self, event, context, config):
         self.event = event
         self.context = context

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import os
-
 import click
 
-from carbon.app import FTPReader, PipeWriter, Writer
+from carbon.app import Config, Lambda, Writer
 from carbon.db import engine
 
 
@@ -48,10 +46,8 @@ def main(feed_type, db, out, ftp, ftp_host, ftp_port, ftp_user, ftp_pass,
     """
     engine.configure(db)
     if ftp:
-        r, w = os.pipe()
-        with open(r, 'rb') as fp_r, open(w, 'wb') as fp_w:
-            ftp_rdr = FTPReader(fp_r, ftp_user, ftp_pass, ftp_path, ftp_host,
-                                ftp_port)
-            PipeWriter(out=fp_w).pipe(ftp_rdr).write(feed_type)
+        cfg = Config(FTP_USER=ftp_user, FTP_PASS=ftp_pass, FTP_PATH=ftp_path,
+                     FTP_HOST=ftp_host, FTP_PORT=ftp_port)
+        Lambda({'feed_type': feed_type}, None, cfg).run()
     else:
         Writer(out=out).write(feed_type)

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import click
 
-from carbon.app import Config, Lambda, Writer
+from carbon.app import Config, FTPFeeder, Writer
 from carbon.db import engine
 
 
@@ -48,6 +48,6 @@ def main(feed_type, db, out, ftp, ftp_host, ftp_port, ftp_user, ftp_pass,
     if ftp:
         cfg = Config(FTP_USER=ftp_user, FTP_PASS=ftp_pass, FTP_PATH=ftp_path,
                      FTP_HOST=ftp_host, FTP_PORT=ftp_port)
-        Lambda({'feed_type': feed_type}, None, cfg).run()
+        FTPFeeder({'feed_type': feed_type}, None, cfg).run()
     else:
         Writer(out=out).write(feed_type)

--- a/lambda.py
+++ b/lambda.py
@@ -3,7 +3,7 @@ import os
 
 import boto3
 
-from carbon.app import Config, Lambda
+from carbon.app import Config, FTPFeeder
 from carbon.db import engine
 
 
@@ -13,4 +13,4 @@ def handler(event, context):
     cfg = Config.from_env()
     cfg.update(json.loads(secret_env))
     engine.configure(cfg['CARBON_DB'])
-    Lambda(event, context, cfg).run()
+    FTPFeeder(event, context, cfg).run()

--- a/lambda.py
+++ b/lambda.py
@@ -1,0 +1,16 @@
+import json
+import os
+
+import boto3
+
+from carbon.app import Config, Lambda
+from carbon.db import engine
+
+
+def handler(event, context):
+    client = boto3.client('secretsmanager')
+    secret_env = client.get_secret_value(SecretId=os.environ['SECRET_ID'])
+    cfg = Config.from_env()
+    cfg.update(json.loads(secret_env))
+    engine.configure(cfg['CARBON_DB'])
+    Lambda(event, context, cfg).run()


### PR DESCRIPTION
This adds a Lambda handler function. There are a few assumptions being
made here. This assumes the Lambda will be triggered by a CloudWatch
event and that the event will pass a JSON structure that indicates the
type of feed to generate. The function is configured through environment
variables. Env vars that contain sensitive information should be added
to an AWS Secrets object.

I'm making some guesses here as to how the event data and secrets get
passed to the Lambda. The documentation suggests it's possible to pass
JSON in both cases, but it's not entirely clear. Some adjustment may be
required after attempting to run this in AWS.