### PR TITLE
Add flake8 to test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 env:
   - TOX_ENV=py36
   - TOX_ENV=coveralls
+  - TOX_ENV=flake8
 install:
   - pip install tox
 script:

--- a/carbon/__init__.py
+++ b/carbon/__init__.py
@@ -7,5 +7,3 @@
 """
 
 __version__ = '1.2.0'
-
-from .app import people, person_feed, articles, article_feed

--- a/carbon/app.py
+++ b/carbon/app.py
@@ -57,7 +57,7 @@ def people():
                   persons.c.PERSONNEL_SUBAREA_CODE,
                   persons.c.APPOINTMENT_END_DATE, orcids.c.ORCID,
                   dlcs.c.ORG_HIER_SCHOOL_AREA_NAME,
-                  dlcs.c.HR_ORG_LEVEL5_NAME,]) \
+                  dlcs.c.HR_ORG_LEVEL5_NAME, ]) \
         .select_from(persons.outerjoin(orcids).join(dlcs)) \
         .where(persons.c.EMAIL_ADDRESS != None) \
         .where(persons.c.LAST_NAME != None) \
@@ -67,7 +67,7 @@ def people():
         .where(persons.c.APPOINTMENT_END_DATE >= datetime(2009, 1, 1)) \
         .where(func.upper(dlcs.c.ORG_HIER_SCHOOL_AREA_NAME).in_(AREAS)) \
         .where(persons.c.PERSONNEL_SUBAREA_CODE.in_(PS_CODES)) \
-        .where(func.upper(persons.c.JOB_TITLE).in_(TITLES))
+        .where(func.upper(persons.c.JOB_TITLE).in_(TITLES))  # noqa: E711
     with closing(engine().connect()) as conn:
         for row in conn.execute(sql):
             yield dict(zip(row.keys(), row))
@@ -82,7 +82,7 @@ def articles():
         .where(aa_articles.c.ARTICLE_ID != None) \
         .where(aa_articles.c.ARTICLE_TITLE != None) \
         .where(aa_articles.c.DOI != None) \
-        .where(aa_articles.c.MIT_ID != None)
+        .where(aa_articles.c.MIT_ID != None)  # noqa: E711
     with closing(engine().connect()) as conn:
         for row in conn.execute(sql):
             yield dict(zip(row.keys(), row))
@@ -123,6 +123,7 @@ def initialize_part(name):
 def group_name(dlc, sub_area):
     qualifier = 'Faculty' if sub_area in ('CFAT', 'CFAN') else 'Non-faculty'
     return "{} {}".format(dlc, qualifier)
+
 
 def _ns(namespace, element):
     return ET.QName(namespace, element)
@@ -301,7 +302,7 @@ class Config(dict):
     def from_env(cls):
         cfg = cls()
         for var in ['FTP_USER', 'FTP_PASS', 'FTP_PATH', 'FTP_HOST',
-                    'CARBON_DB',]:
+                    'CARBON_DB', ]:
             cfg[var] = os.environ.get(var)
         return cfg
 

--- a/carbon/db.py
+++ b/carbon/db.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os
 
 from sqlalchemy import (create_engine, Table, Column, String, Date, MetaData,
-                        ForeignKey, Numeric, Text, Unicode, UnicodeText)
+                        ForeignKey, Numeric, Unicode, UnicodeText)
 
 
 os.environ['NLS_LANG'] = 'AMERICAN_AMERICA.UTF8'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,8 @@ def articles_data(aa_data):
         B.ARTICLE(
             B.AA_MATCH_SCORE('0.9'),
             B.ARTICLE_ID('1234567'),
-            B.ARTICLE_TITLE(u'Interaction between hatsopoulos microfluids and the Yawning Abyss of Chaos ☈.'),
+            B.ARTICLE_TITLE('Interaction between hatsopoulos microfluids and '
+                            'the Yawning Abyss of Chaos ☈.'),
             B.ARTICLE_YEAR('1999'),
             B.AUTHORS(u'McRandallson, Randall M.|Lord, Dark|☭'),
             B.DOI('10.0000/1234LETTERS56'),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,10 +6,9 @@ import os
 from lxml import etree as ET
 import pytest
 
-from carbon import people, articles
 from carbon.app import (person_feed, ns, NSMAP, add_child, initials,
                         article_feed, group_name, Writer, PipeWriter,
-                        FTPReader)
+                        FTPReader, people, articles)
 
 
 pytestmark = pytest.mark.usefixtures('load_data')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,coverage
+envlist = py36,coverage,flake8
 skipsdist = True
 
 [testenv]
@@ -8,6 +8,7 @@ deps =
   pipenv
   {coverage,coveralls}: pytest-cov
   coveralls: coveralls
+  flake8: flake8
 setenv =
   {coverage,coveralls}: PYTEST_COV="--cov=carbon"
 commands =
@@ -19,3 +20,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
   {[testenv]commands}
   coveralls
+
+[testenv:flake8]
+commands =
+  flake8 carbon


### PR DESCRIPTION
Closes #40. This adds a tox environment for flake8 and a corresponding
entry to the travis test matrix. Also fixes all the flake8 errors.