### PR TITLE
Use Lambda event object to set env vars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ If you need to deploy a new package outside of Travis then do the following, *no
 Configuration
 ^^^^^^^^^^^^^
 
-In order for the Lambda to run, carbon needs a few environment variables set.
+In order for the Lambda to run, carbon needs a few environment variables set. These can either be set in the environment or passed to the Lambda function through the event JSON object. Variables set using the event object will overwrite those set in the environment.
 
 +-----------+-------------------------------------------------------------+
 | Variable  | Description                                                 |

--- a/carbon/app.py
+++ b/carbon/app.py
@@ -44,6 +44,9 @@ TITLES = (
     'VISITING SENIOR LECTURER', 'PART-TIME FLEXIBLE/LL',
 )
 
+ENV_VARS = ('FTP_USER', 'FTP_PASS', 'FTP_PATH', 'FTP_HOST', 'FTP_PORT',
+            'CARBON_DB')
+
 
 def people():
     """A person generator.
@@ -301,8 +304,7 @@ class Config(dict):
     @classmethod
     def from_env(cls):
         cfg = cls()
-        for var in ['FTP_USER', 'FTP_PASS', 'FTP_PATH', 'FTP_HOST',
-                    'CARBON_DB', ]:
+        for var in ENV_VARS:
             cfg[var] = os.environ.get(var)
         return cfg
 

--- a/lambda.py
+++ b/lambda.py
@@ -3,7 +3,7 @@ import os
 
 import boto3
 
-from carbon.app import Config, FTPFeeder
+from carbon.app import Config, ENV_VARS, FTPFeeder
 from carbon.db import engine
 
 
@@ -12,6 +12,7 @@ def handler(event, context):
     secret = client.get_secret_value(SecretId=os.environ['SECRET_ID'])
     secret_env = json.loads(secret['SecretString'])
     cfg = Config.from_env()
+    cfg.update({k: event[k] for k in ENV_VARS if k in event})
     cfg.update(secret_env)
     engine.configure(cfg['CARBON_DB'])
     FTPFeeder(event, context, cfg).run()


### PR DESCRIPTION
It turns out the easiest way to handle this with the tools we have
available is to pass some of the environment variables to the function
through the Cloudwatch event object. Both env vars and the event object
can be used, with the event object taking precedence.