### PR TITLE
Update Lambda publishing step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ If you need to deploy a new package outside of Travis then do the following, *no
 
     $ cd carbon
     $ ./build.sh
-    $ ./publish.sh
+    $ ./publish.sh --upload
 
 Configuration
 ^^^^^^^^^^^^^

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ DIST_DIR=dist-aws
 S3_BUCKET=carbon-deploy
 LIBAIO_SO=libaio.so.1.0.1
 ORACLE_ZIP=instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
-PACKAGE=carbon-`git rev-parse --short HEAD`.zip
+PACKAGE=carbon.zip
 
 mkdir -p $BUILD_DIR/lib
 mkdir -p $DIST_DIR

--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-PACKAGE=carbon-`git rev-parse --short HEAD`.zip
+PACKAGE=carbon.zip
 S3_BUCKET=carbon-deploy
 
-aws lambda update-function-code --function-name carbon-test --s3-bucket \
-  $S3_BUCKET --s3-key $PACKAGE --region us-east-1
+for arg in $@; do
+  if [ "$arg" = '--upload' ]; then
+    aws s3 cp "dist-aws/$PACKAGE" "s3://$S3_BUCKET/$PACKAGE"
+    break
+  fi
+done
+
+aws lambda update-function-code --function-name mitlib-global-carbon \
+  --s3-bucket $S3_BUCKET --s3-key $PACKAGE --region us-east-1


### PR DESCRIPTION
This changes the name of the Lambda deployment package to always be
`carbon.zip`. We don't currently have the infrastructure to handle
changing Lambda aliases so we'll just overwrite the existing Lambda and
let the two week delay in staging/prod cron schedules highlight any
issues. Downgrading the Lambda to an older version can be done manually
using the deployment instructions in the README.