### PR TITLE
Add Fargate functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ wheel:
 	pipenv run python setup.py bdist_wheel
 
 container:
-	docker build -t $(ECR_REGISTRY)/carbon:latest \
-		-t $(ECR_REGISTRY)/carbon:`git describe --always` \
-		-t carbon:latest .
+	docker build -t $(ECR_REGISTRY)/carbon-stage:latest \
+		-t $(ECR_REGISTRY)/carbon-stage:`git describe --always` \
+		-t $(ECR_REGISTRY)/carbon-prod:latest \
+		-t $(ECR_REGISTRY)/carbon-prod:`git describe --always` \
+		-t carbon-stage:latest .
 
 dist: deps wheel container ## Build docker image
 	@tput setaf 2
@@ -51,5 +53,7 @@ update: ## Update all python dependencies
 
 publish: ## Push and tag the latest image (use `make dist && make publish`)
 	$$(aws ecr get-login --no-include-email --region us-east-1)
-	docker push $(ECR_REGISTRY)/carbon:latest
-	docker push $(ECR_REGISTRY)/carbon:`git describe --always`
+	docker push $(ECR_REGISTRY)/carbon-stage:latest
+	docker push $(ECR_REGISTRY)/carbon-stage:`git describe --always`
+	docker push $(ECR_REGISTRY)/carbon-prod:latest
+	docker push $(ECR_REGISTRY)/carbon-prod:`git describe --always`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,14 +19,14 @@ def runner():
 
 
 def test_people_returns_people(runner, xml_data):
-    res = runner.invoke(main, ['--db', 'sqlite://', 'people'])
+    res = runner.invoke(main, ['--db', 'sqlite://', '-o', '-', 'people'])
     assert res.exit_code == 0
     assert res.stdout_bytes == \
         ET.tostring(xml_data, encoding="UTF-8", xml_declaration=True)
 
 
 def test_articles_returns_articles(runner, articles_data):
-    res = runner.invoke(main, ['--db', 'sqlite://', 'articles'])
+    res = runner.invoke(main, ['--db', 'sqlite://', '-o', '-', 'articles'])
     assert res.exit_code == 0
     assert res.stdout_bytes == \
         ET.tostring(articles_data, encoding='UTF-8', xml_declaration=True)


### PR DESCRIPTION
This adds a few pieces to make carbon work on Fargate. The main change
is to add SNS notification directly into the app. Cloudwatch logging
from the container's stdout is a little flakey. The build process will
now publish the container to both the stage and prod ECR repos. With
real CI/CD we'd just publish to stage, but with Travis this is the best
we can do.