### PR TITLE
Add check for existence of arrive date

### DIFF
--- a/carbon/app.py
+++ b/carbon/app.py
@@ -325,9 +325,10 @@ def _add_person(xf, person):
     add_child(record, 'field',
               group_name(person['DLC_NAME'], person['PERSONNEL_SUBAREA_CODE']),
               name='[PrimaryGroupDescriptor]')
-    add_child(record, 'field',
-              person['ORIGINAL_HIRE_DATE'].strftime("%Y-%m-%d"),
-              name='[ArriveDate]')
+    if person['ORIGINAL_HIRE_DATE'] is not None:
+        add_child(record, 'field',
+                  person['ORIGINAL_HIRE_DATE'].strftime("%Y-%m-%d"),
+                  name='[ArriveDate]')
     add_child(record, 'field',
               person['APPOINTMENT_END_DATE'].strftime("%Y-%m-%d"),
               name='[LeaveDate]')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,6 @@ def xml_records(E):
             E.field('1', {'name': '[LoginAllowed]'}),
             E.field('Nuclear Science Non-faculty',
                     {'name': '[PrimaryGroupDescriptor]'}),
-            E.field('2015-01-01', {'name': '[ArriveDate]'}),
             E.field('2999-12-31', {'name': '[LeaveDate]'}),
             E.field('http://example.com/2', {'name': '[Generic01]'}),
             E.field('COAC', {'name': '[Generic02]'}),

--- a/tests/fixtures/data.yml
+++ b/tests/fixtures/data.yml
@@ -26,7 +26,7 @@ person:
     MIDDLE_NAME: Hǫlgabrúðr
     LAST_NAME: Hammerson
     EMAIL_ADDRESS: thor@example.com
-    ORIGINAL_HIRE_DATE: !!timestamp 2015-01-01 00:00:00.0
+    ORIGINAL_HIRE_DATE: null
     APPOINTMENT_END_DATE: !!timestamp 2999-12-31 00:00:00.0
     JOB_TITLE: Visiting Engineer
     PERSONNEL_SUBAREA_CODE: COAC


### PR DESCRIPTION
We ran into a case where an individual does not have a start date which
caused the upload to fail. My documentation tells me that this field is
not required for the Elements feed, so the solution here is to just omit
the field when the data is not available.