### PR TITLE
Skip people without an arrive date

### DIFF
--- a/carbon/app.py
+++ b/carbon/app.py
@@ -69,6 +69,7 @@ def people():
         .where(persons.c.KRB_NAME_UPPERCASE != None) \
         .where(persons.c.KRB_NAME_UPPERCASE != 'UNKNOWN') \
         .where(persons.c.MIT_ID != None) \
+        .where(persons.c.ORIGINAL_HIRE_DATE != None) \
         .where(persons.c.APPOINTMENT_END_DATE >= datetime(2009, 1, 1)) \
         .where(func.upper(dlcs.c.ORG_HIER_SCHOOL_AREA_NAME).in_(AREAS)) \
         .where(persons.c.PERSONNEL_SUBAREA_CODE.in_(PS_CODES)) \
@@ -325,10 +326,9 @@ def _add_person(xf, person):
     add_child(record, 'field',
               group_name(person['DLC_NAME'], person['PERSONNEL_SUBAREA_CODE']),
               name='[PrimaryGroupDescriptor]')
-    if person['ORIGINAL_HIRE_DATE'] is not None:
-        add_child(record, 'field',
-                  person['ORIGINAL_HIRE_DATE'].strftime("%Y-%m-%d"),
-                  name='[ArriveDate]')
+    add_child(record, 'field',
+              person['ORIGINAL_HIRE_DATE'].strftime("%Y-%m-%d"),
+              name='[ArriveDate]')
     add_child(record, 'field',
               person['APPOINTMENT_END_DATE'].strftime("%Y-%m-%d"),
               name='[LeaveDate]')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,7 @@ def xml_records(E):
             E.field('1', {'name': '[LoginAllowed]'}),
             E.field('Nuclear Science Non-faculty',
                     {'name': '[PrimaryGroupDescriptor]'}),
+            E.field('2015-01-01', {'name': '[ArriveDate]'}),
             E.field('2999-12-31', {'name': '[LeaveDate]'}),
             E.field('http://example.com/2', {'name': '[Generic01]'}),
             E.field('COAC', {'name': '[Generic02]'}),

--- a/tests/fixtures/data.yml
+++ b/tests/fixtures/data.yml
@@ -26,7 +26,7 @@ person:
     MIDDLE_NAME: Hǫlgabrúðr
     LAST_NAME: Hammerson
     EMAIL_ADDRESS: thor@example.com
-    ORIGINAL_HIRE_DATE: null
+    ORIGINAL_HIRE_DATE: !!timestamp 2015-01-01 00:00:00.0
     APPOINTMENT_END_DATE: !!timestamp 2999-12-31 00:00:00.0
     JOB_TITLE: Visiting Engineer
     PERSONNEL_SUBAREA_CODE: COAC
@@ -115,3 +115,22 @@ dlc:
     HR_ORG_UNIT_ID: "6"
     DLC_NAME: Nuclear Science
     ORG_HIER_SCHOOL_AREA_NAME: ENGINEERING AREA
+---
+person:
+    MIT_ID: "123450"
+    KRB_NAME_UPPERCASE: NOARRIVEDATE
+    FIRST_NAME: Egil
+    MIDDLE_NAME: Axehand
+    LAST_NAME: Skallagrimsson
+    EMAIL_ADDRESS: egil@example.com
+    APPOINTMENT_END_DATE: !!timestamp 2999-12-31 00:00:00.0
+    JOB_TITLE: Adjunct Professor
+    PERSONNEL_SUBAREA_CODE: CFAT
+    HR_ORG_UNIT_ID: "6"
+orcid:
+    MIT_ID: "123450"
+    ORCID: http://example.com/1
+dlc:
+    HR_ORG_UNIT_ID: "6"
+    DLC_NAME: Chemistry
+    ORG_HIER_SCHOOL_AREA_NAME: SCIENCE AREA


### PR DESCRIPTION
If someone is missing a start date we need to skip them altogether. This
backs out the last commit and filters out people at the query level.

We have only encountered a single instance of someone missing a start
date so my assumption is that this is just a data error in some upstream
system.