### PR TITLE
Fix for Oracle ZIP Location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/carbon-dev
 ### End of Terraform-generated header                            ###
 
 SHELL=/bin/bash
-S3_BUCKET=shared-files-222053980223
-ORACLE_ZIP=instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
+S3_BUCKET:=shared-files-$(shell aws sts get-caller-identity --query "Account" --output text)
+ORACLE_ZIP:=instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
 help: ## Print this message


### PR DESCRIPTION
### What does this PR do?

* Update the environment variable definitions in the Makefile

### Helpful background context

The previous Makefile had a hardcoded name for an S3 bucket that holds a copy of the Oracle library .zip file. This makes that S3 bucket name dynamic to match the dev/stage/prod account from which it should be pulled.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IN-615

### How can a reviewer manually see the effects of these changes?

The problem was discovered in the failure of the [stage-deploy workflow run](https://github.com/MITLibraries/carbon/actions/runs/3331238125/jobs/5511040163#step:7:60). The wrong S3 bucket was being accessed.

To test this, checkout this branch locally, authenticate to AWS Dev1 account and run

```bash
make distclean
make deps
```

and you should see the .zip file get downloaded from the Dev1 S3 bucket.  Then, authenticate to AWS Stage-Workloads account and run

```bash
make distclean
make deps
```

and you should see the .zip file get downloaded from the Stage-Workloads S3 bucket.

It was the `make deps` command that was failing in the GHA stage deploy workflow.

### Includes new or updated dependencies?

NO

### Developer
- [X] README is updated to reflect all changes as needed
- [X] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated to reflect all changes or is not needed
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
