### PR TITLE
In 884 refactor config loading

### DIFF
--- a/carbon/app.py
+++ b/carbon/app.py
@@ -455,15 +455,6 @@ def _add_person(xf: IO, person: dict[str, Any]) -> None:
     xf.write(record)
 
 
-class Config(dict):
-    @classmethod
-    def from_env(cls) -> Config:
-        cfg = cls()
-        for var in ENV_VARS:
-            cfg[var] = os.environ.get(var)
-        return cfg
-
-
 class FTPFeeder:
     def __init__(
         self,
@@ -481,11 +472,11 @@ class FTPFeeder:
         with open(r, "rb") as fp_r, open(w, "wb") as fp_w:
             ftp_rdr = FTPReader(
                 fp_r,
-                self.config["FTP_USER"],
-                self.config["FTP_PASS"],
-                self.config["FTP_PATH"],
-                self.config["FTP_HOST"],
-                int(self.config["FTP_PORT"]),
+                self.config["SYMPLECTIC_FTP_USER"],
+                self.config["SYMPLECTIC_FTP_PASS"],
+                self.config["SYMPLECTIC_FTP_PATH"],
+                self.config["SYMPLECTIC_FTP_HOST"],
+                int(self.config["SYMPLECTIC_FTP_PORT"]),
                 self.ssl_ctx,
             )
             PipeWriter(out=fp_w).pipe(ftp_rdr).write(feed_type)

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 
@@ -44,7 +43,7 @@ def main(sns_topic: str | None = None) -> None:  # noqa: ARG001
     config_values = load_config_values()
     root_logger = logging.getLogger()
     logger.info(configure_logger(root_logger, os.getenv("LOG_LEVEL", "INFO")))
-    # configure_sentry()
+    # configure_sentry() # noqa: ERA001
     logger.info("Carbon config settings loaded for environment: %s")
 
     engine.configure(config_values["CONNECTION_STRING"])

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -1,11 +1,10 @@
 import json
 import logging
 import os
-from typing import IO
 
 import click
 
-from carbon.app import FTPFeeder, Writer, sns_log
+from carbon.app import FTPFeeder, sns_log
 from carbon.config import configure_logger, load_config_values  # configure_sentry
 from carbon.db import engine
 
@@ -14,41 +13,6 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.version_option()
-@click.argument(
-    "feed_type", envvar="FEED_TYPE", type=click.Choice(["people", "articles"])
-)
-@click.option("--db", envvar="CONNECTION_STRING", help="Database connection string")
-@click.option("-o", "--out", help="Output file", type=click.File("wb"))
-@click.option(
-    "--ftp",
-    is_flag=True,
-    help="Send output to FTP server; do not use this with the -o/--out option",
-)
-@click.option(
-    "--ftp-host",
-    envvar="SYMPLECTIC_FTP_HOST",
-    help="Hostname of FTP server",
-    default="localhost",
-    show_default=True,
-)
-@click.option(
-    "--ftp-port",
-    envvar="SYMPLECTIC_FTP_PORT",
-    help="FTP server port",
-    default=21,
-    show_default=True,
-)
-@click.option("--ftp-user", envvar="SYMPLECTIC_FTP_USER", help="FTP username")
-@click.option("--ftp-pass", envvar="SYMPLECTIC_FTP_PASS", help="FTP password")
-@click.option(
-    "--ftp-path", envvar="SYMPLECTIC_FTP_PATH", help="Full path to file on FTP server"
-)
-@click.option(
-    "--secret-id",
-    help="AWS Secrets id containing DB connection "
-    "string and FTP password. If given, will "
-    "override other command line options.",
-)
 @click.option(
     "--sns-topic",
     help="AWS SNS Topic ARN. If given, a message "
@@ -57,20 +21,7 @@ logger = logging.getLogger(__name__)
     "the outcome of the load.",
 )
 @sns_log
-def main(
-    feed_type: str,
-    db: str,
-    out: IO,
-    ftp_host: str,
-    ftp_port: int,
-    ftp_user: str,
-    ftp_pass: str,
-    ftp_path: str,
-    secret_id: str,
-    sns_topic: str,  # noqa: ARG001
-    *,
-    ftp: bool,
-) -> None:
+def main(sns_topic: str | None = None) -> None:  # noqa: ARG001
     """Generate feeds for Symplectic Elements.
 
     Specify which FEED_TYPE should be generated. This should be either
@@ -91,33 +42,13 @@ def main(
     --ftp should be used.
     """
     config_values = load_config_values()
-
-    # [TEMPORARY] In order to pass the current test, config_values
-    #   must be updated with any arguments set when the function is
-    #   invoked.
-    # Note: For FTP port, the default value is 21, but we currently do not have
-    #   an environment variable set. We may need to create an environment variable
-    #   SYMPLECTIC_FTP_PORT for consistency.
-    config_values.update(
-        {
-            "CONNECTION_STRING": db,
-            "SYMPLECTIC_FTP_USER": ftp_user,
-            "SYMPLECTIC_FTP_PASS": ftp_pass,
-            "SYMPLECTIC_FTP_PATH": ftp_path,
-            "SYMPLECTIC_FTP_HOST": ftp_host,
-            "SYMPLECTIC_FTP_PORT": ftp_port,
-        }
-    )
-
     root_logger = logging.getLogger()
     logger.info(configure_logger(root_logger, os.getenv("LOG_LEVEL", "INFO")))
     # configure_sentry()
     logger.info("Carbon config settings loaded for environment: %s")
 
     engine.configure(config_values["CONNECTION_STRING"])
-    if ftp:
-        click.echo("Starting carbon run for {}".format(feed_type))
-        FTPFeeder({"feed_type": feed_type}, None, config_values).run()
-        click.echo("Finished carbon run for {}".format(feed_type))
-    else:
-        Writer(out=out).write(feed_type)
+
+    click.echo("Starting carbon run for {}".format(config_values["FEED_TYPE"]))
+    FTPFeeder({"feed_type": config_values["FEED_TYPE"]}, config_values).run()
+    click.echo("Finished carbon run for {}".format(config_values["FEED_TYPE"]))

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -1,12 +1,15 @@
 import json
+import logging
 import os
 from typing import IO
 
 import click
 
 from carbon.app import FTPFeeder, Writer, sns_log
-from carbon.config import configure_logger, configure_sentry, load_config_values
+from carbon.config import configure_logger, load_config_values  # configure_sentry
 from carbon.db import engine
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -106,7 +109,10 @@ def main(
         }
     )
 
+    root_logger = logging.getLogger()
+    logger.info(configure_logger(root_logger, os.getenv("LOG_LEVEL", "INFO")))
     # configure_sentry()
+    logger.info("Carbon config settings loaded for environment: %s")
 
     engine.configure(config_values["CONNECTION_STRING"])
     if ftp:

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -1,18 +1,20 @@
 import json
+import os
 from typing import IO
 
-import boto3
 import click
 
-from carbon.app import Config, FTPFeeder, Writer, sns_log
-from carbon.config import configure_sentry
+from carbon.app import FTPFeeder, Writer, sns_log
+from carbon.config import configure_logger, configure_sentry, load_config_values
 from carbon.db import engine
 
 
 @click.command()
 @click.version_option()
-@click.argument("feed_type", type=click.Choice(["people", "articles"]))
-@click.option("--db", envvar="CARBON_DB", help="Database connection string")
+@click.argument(
+    "feed_type", envvar="FEED_TYPE", type=click.Choice(["people", "articles"])
+)
+@click.option("--db", envvar="CONNECTION_STRING", help="Database connection string")
 @click.option("-o", "--out", help="Output file", type=click.File("wb"))
 @click.option(
     "--ftp",
@@ -21,21 +23,23 @@ from carbon.db import engine
 )
 @click.option(
     "--ftp-host",
-    envvar="FTP_HOST",
+    envvar="SYMPLECTIC_FTP_HOST",
     help="Hostname of FTP server",
     default="localhost",
     show_default=True,
 )
 @click.option(
     "--ftp-port",
-    envvar="FTP_PORT",
+    envvar="SYMPLECTIC_FTP_PORT",
     help="FTP server port",
     default=21,
     show_default=True,
 )
-@click.option("--ftp-user", envvar="FTP_USER", help="FTP username")
-@click.option("--ftp-pass", envvar="FTP_PASS", help="FTP password")
-@click.option("--ftp-path", envvar="FTP_PATH", help="Full path to file on FTP server")
+@click.option("--ftp-user", envvar="SYMPLECTIC_FTP_USER", help="FTP username")
+@click.option("--ftp-pass", envvar="SYMPLECTIC_FTP_PASS", help="FTP password")
+@click.option(
+    "--ftp-path", envvar="SYMPLECTIC_FTP_PATH", help="Full path to file on FTP server"
+)
 @click.option(
     "--secret-id",
     help="AWS Secrets id containing DB connection "
@@ -83,26 +87,31 @@ def main(
     server. The server should support FTP over TLS. Only one of -o/--out or
     --ftp should be used.
     """
-    cfg = Config(
-        CARBON_DB=db,
-        FTP_USER=ftp_user,
-        FTP_PASS=ftp_pass,
-        FTP_PATH=ftp_path,
-        FTP_HOST=ftp_host,
-        FTP_PORT=ftp_port,
+    config_values = load_config_values()
+
+    # [TEMPORARY] In order to pass the current test, config_values
+    #   must be updated with any arguments set when the function is
+    #   invoked.
+    # Note: For FTP port, the default value is 21, but we currently do not have
+    #   an environment variable set. We may need to create an environment variable
+    #   SYMPLECTIC_FTP_PORT for consistency.
+    config_values.update(
+        {
+            "CONNECTION_STRING": db,
+            "SYMPLECTIC_FTP_USER": ftp_user,
+            "SYMPLECTIC_FTP_PASS": ftp_pass,
+            "SYMPLECTIC_FTP_PATH": ftp_path,
+            "SYMPLECTIC_FTP_HOST": ftp_host,
+            "SYMPLECTIC_FTP_PORT": ftp_port,
+        }
     )
-    configure_sentry()
 
-    if secret_id is not None:
-        client = boto3.client("secretsmanager")
-        secret = client.get_secret_value(SecretId=secret_id)
-        secret_env = json.loads(secret["SecretString"])
-        cfg.update(secret_env)
+    # configure_sentry()
 
-    engine.configure(cfg["CARBON_DB"])
+    engine.configure(config_values["CONNECTION_STRING"])
     if ftp:
-        click.echo(f"Starting carbon run for {feed_type}")
-        FTPFeeder({"feed_type": feed_type}, cfg).run()
-        click.echo(f"Finished carbon run for {feed_type}")
+        click.echo("Starting carbon run for {}".format(feed_type))
+        FTPFeeder({"feed_type": feed_type}, None, config_values).run()
+        click.echo("Finished carbon run for {}".format(feed_type))
     else:
         Writer(out=out).write(feed_type)

--- a/carbon/config.py
+++ b/carbon/config.py
@@ -18,16 +18,19 @@ ENV_VARS = [
 
 def configure_logger(logger: logging.Logger, log_level_string: str) -> str:
     if log_level_string.upper() not in logging.getLevelNamesMapping():
-        raise ValueError(f"'{log_level_string}' is not a valid Python logging level")
+        invalid_logging_level_message = (
+            f"'{log_level_string}' is not a valid Python logging level"
+        )
+        raise ValueError(invalid_logging_level_message)
     log_level = logging.getLevelName(log_level_string.upper())
-    if log_level < 20:
+    if log_level < 20:  # noqa: PLR2004
         logging.basicConfig(
             format="%(asctime)s %(levelname)s %(name)s.%(funcName)s() line %(lineno)d: "
             "%(message)s"
         )
         logger.setLevel(log_level)
         for handler in logging.root.handlers:
-            handler.addFilter(logging.Filter("patronload"))
+            handler.addFilter(logging.Filter("carbon"))
     else:
         logging.basicConfig(
             format="%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"

--- a/carbon/config.py
+++ b/carbon/config.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 import sentry_sdk
@@ -13,6 +14,29 @@ ENV_VARS = [
     "DATAWAREHOUSE_CLOUDCONNECTOR_JSON",
     "SYMPLECTIC_FTP_JSON",
 ]
+
+
+def configure_logger(logger: logging.Logger, log_level_string: str) -> str:
+    if log_level_string.upper() not in logging.getLevelNamesMapping():
+        raise ValueError(f"'{log_level_string}' is not a valid Python logging level")
+    log_level = logging.getLevelName(log_level_string.upper())
+    if log_level < 20:
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)s %(name)s.%(funcName)s() line %(lineno)d: "
+            "%(message)s"
+        )
+        logger.setLevel(log_level)
+        for handler in logging.root.handlers:
+            handler.addFilter(logging.Filter("patronload"))
+    else:
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"
+        )
+        logger.setLevel(log_level)
+    return (
+        f"Logger '{logger.name}' configured with level="
+        f"{logging.getLevelName(logger.getEffectiveLevel())}"
+    )
 
 
 def configure_sentry() -> str:

--- a/carbon/config.py
+++ b/carbon/config.py
@@ -1,12 +1,47 @@
+import json
 import os
 
 import sentry_sdk
 
+ENV_VARS = [
+    "FEED_TYPE",
+    "LOG_LEVEL",
+    "SENTRY_DSN",
+    "SNS_TOPIC",
+    "SYMPLECTIC_FTP_PATH",
+    "WORKSPACE",
+    "DATAWAREHOUSE_CLOUDCONNECTOR_JSON",
+    "SYMPLECTIC_FTP_JSON",
+]
+
 
 def configure_sentry() -> str:
+    """Establish Carbon project on Sentry.
+
+    Returns:
+        str: Status on whether Sentry was successfully configured.
+    """
     env = os.getenv("WORKSPACE")
     sentry_dsn = os.getenv("SENTRY_DSN")
     if sentry_dsn and sentry_dsn.lower() != "none":
         sentry_sdk.init(sentry_dsn, environment=env)
         return f"Sentry DSN found, exceptions will be sent to Sentry with env={env}"
     return "No Sentry DSN found, exceptions will not be sent to Sentry"
+
+
+def load_config_values() -> dict:
+    """Load required ENV variables into a 'config_values' dictionary.
+
+    Returns:
+        dict: Required ENV variables.
+    """
+    config_values = {}
+    for config_variable in ENV_VARS:
+        if config_variable in [
+            "DATAWAREHOUSE_CLOUDCONNECTOR_JSON",
+            "SYMPLECTIC_FTP_JSON",
+        ]:
+            config_values.update(json.loads(os.environ[config_variable]))
+        config_values[config_variable] = os.environ[config_variable]
+
+    return config_values

--- a/carbon/config.py
+++ b/carbon/config.py
@@ -66,6 +66,7 @@ def load_config_values() -> dict:
             "SYMPLECTIC_FTP_JSON",
         ]:
             config_values.update(json.loads(os.environ[config_variable]))
-        config_values[config_variable] = os.environ[config_variable]
+        else:
+            config_values[config_variable] = os.environ[config_variable]
 
     return config_values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,23 +22,20 @@ def _app_init():
 
 
 @pytest.fixture(autouse=True)
-def test_env(ftp_server):
-    os.environ = {
-        "FEED_TYPE": "test_feed_type",
-        "LOG_LEVEL": "INFO",
-        "SENTRY_DSN": "test_sentry_dsn",
-        "SNS_TOPIC": "test_sns_topic",
-        "SYMPLECTIC_FTP_PATH": "test_symplectic_ftp_path",
-        "WORKSPACE": "test",
-        "DATAWAREHOUSE_CLOUDCONNECTOR_JSON": '{"CONNECTION_STRING": "sqlite://"}',
-        "SYMPLECTIC_FTP_JSON": (
-            '{"SYMPLECTIC_FTP_HOST": "test_symplectic_host", '
-            '"SYMPLECTIC_FTP_USER": "test_user", '
-            '"SYMPLECTIC_FTP_PASS": "test_pass"}'
-        ),
-    }
-
-    yield
+def _test_env():
+    os.environ["FEED_TYPE"] = "test_feed_type"
+    os.environ["LOG_LEVEL"] = "INFO"
+    os.environ["SENTRY_DSN"] = "test_sentry_dsn"
+    os.environ["SNS_TOPIC"] = "test_sns_topic"
+    os.environ["WORKSPACE"] = "test"
+    os.environ["DATAWAREHOUSE_CLOUDCONNECTOR_JSON"] = '{"CONNECTION_STRING": "sqlite://"}'
+    os.environ["SYMPLECTIC_FTP_PATH"] = "/people.xml"
+    os.environ["SYMPLECTIC_FTP_JSON"] = (
+        '{"SYMPLECTIC_FTP_HOST": "localhost", '
+        '"SYMPLECTIC_FTP_PORT": "test_symplectic_ftp_port",'
+        '"SYMPLECTIC_FTP_USER": "user", '
+        '"SYMPLECTIC_FTP_PASS": "pass"}'
+    )
 
 
 @pytest.fixture(scope="session")
@@ -165,7 +162,7 @@ def xml_records(e):
 
 
 @pytest.fixture
-def xml_data(e, xml_records):
+def people_data(e, xml_records):
     return e.records(*xml_records)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,23 @@ def _app_init():
 
 
 @pytest.fixture(autouse=True)
-def _test_env():
-    os.environ["WORKSPACE"] = "test"
+def test_env(ftp_server):
+    os.environ = {
+        "FEED_TYPE": "test_feed_type",
+        "LOG_LEVEL": "INFO",
+        "SENTRY_DSN": "test_sentry_dsn",
+        "SNS_TOPIC": "test_sns_topic",
+        "SYMPLECTIC_FTP_PATH": "test_symplectic_ftp_path",
+        "WORKSPACE": "test",
+        "DATAWAREHOUSE_CLOUDCONNECTOR_JSON": '{"CONNECTION_STRING": "sqlite://"}',
+        "SYMPLECTIC_FTP_JSON": (
+            '{"SYMPLECTIC_FTP_HOST": "test_symplectic_host", '
+            '"SYMPLECTIC_FTP_USER": "test_user", '
+            '"SYMPLECTIC_FTP_PASS": "test_pass"}'
+        ),
+    }
+
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,45 +14,63 @@ def runner():
     return CliRunner()
 
 
-def test_people_returns_people(runner, xml_data):
-    res = runner.invoke(main, ["--db", "sqlite://", "-o", "-", "people"])
-    assert res.exit_code == 0
-    assert res.stdout_bytes == ET.tostring(
-        xml_data, encoding="UTF-8", xml_declaration=True
+def test_people_returns_people(runner, people_data, ftp_server):
+    s, d = ftp_server
+    os.environ["FEED_TYPE"] = "people"
+    os.environ["SYMPLECTIC_FTP_PATH"] = "/people.xml"
+    os.environ["SYMPLECTIC_FTP_JSON"] = (
+        '{"SYMPLECTIC_FTP_HOST": "localhost", '
+        f'"SYMPLECTIC_FTP_PORT": "{s[1]}",'
+        '"SYMPLECTIC_FTP_USER": "user", '
+        '"SYMPLECTIC_FTP_PASS": "pass"}'
+    )
+
+    result = runner.invoke(main)
+    assert result.exit_code == 0
+
+    people_element = ET.parse(os.path.join(d, "people.xml"))
+    people_xml_string = ET.tostring(
+        people_element, encoding="UTF-8", xml_declaration=True
+    )
+    assert people_xml_string == ET.tostring(
+        people_data, encoding="UTF-8", xml_declaration=True
     )
 
 
-def test_articles_returns_articles(runner, articles_data):
-    res = runner.invoke(main, ["--db", "sqlite://", "-o", "-", "articles"])
-    assert res.exit_code == 0
-    assert res.stdout_bytes == ET.tostring(
+def test_articles_returns_articles(runner, articles_data, ftp_server):
+    s, d = ftp_server
+    os.environ["FEED_TYPE"] = "articles"
+    os.environ["SYMPLECTIC_FTP_PATH"] = "/articles.xml"
+    os.environ["SYMPLECTIC_FTP_JSON"] = (
+        '{"SYMPLECTIC_FTP_HOST": "localhost", '
+        f'"SYMPLECTIC_FTP_PORT": "{s[1]}",'
+        '"SYMPLECTIC_FTP_USER": "user", '
+        '"SYMPLECTIC_FTP_PASS": "pass"}'
+    )
+
+    result = runner.invoke(main)
+    assert result.exit_code == 0
+
+    articles_element = ET.parse(os.path.join(d, "articles.xml"))
+    articles_xml_string = ET.tostring(
+        articles_element, encoding="UTF-8", xml_declaration=True
+    )
+    assert articles_xml_string == ET.tostring(
         articles_data, encoding="UTF-8", xml_declaration=True
     )
 
 
-def test_file_is_ftped(runner, ftp_server_wrapper):
-    s, d = ftp_server_wrapper
-    res = runner.invoke(
-        main,
-        [
-            "--db",
-            "sqlite://",
-            "--ftp",
-            "--ftp-port",
-            s[1],
-            "--ftp-user",
-            "user",
-            "--ftp-pass",
-            "pass",
-            "--ftp-path",
-            "/peeps.xml",
-            "people",
-        ],
+def test_file_is_ftped(runner, ftp_server):
+    s, d = ftp_server
+    os.environ["FEED_TYPE"] = "people"
+    os.environ["SYMPLECTIC_FTP_PATH"] = "/peeps.xml"
+    os.environ["SYMPLECTIC_FTP_JSON"] = (
+        '{"SYMPLECTIC_FTP_HOST": "localhost", '
+        f'"SYMPLECTIC_FTP_PORT": "{s[1]}",'
+        '"SYMPLECTIC_FTP_USER": "user", '
+        '"SYMPLECTIC_FTP_PASS": "pass"}'
     )
-    assert res.exit_code == 0
-    xml = ET.parse(os.path.join(d, "peeps.xml"))
-    xp = xml.xpath(
-        "/s:records/s:record/s:field[@name='[FirstName]']",
-        namespaces={"s": "http://www.symplectic.co.uk/hrimporter"},
-    )
-    assert xp[1].text == "Þorgerðr"
+
+    result = runner.invoke(main)
+    assert result.exit_code == 0
+    assert os.path.exists(os.path.join(d, "peeps.xml"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,28 @@
-from carbon.config import configure_sentry
+import logging
+
+import pytest
+
+from carbon.config import configure_logger, configure_sentry, load_config_values
+
+
+def test_configure_logger_with_invalid_level_raises_error():
+    logger = logging.getLogger(__name__)
+    with pytest.raises(ValueError, match="'oops' is not a valid Python logging level"):
+        configure_logger(logger, log_level_string="oops")
+
+
+def test_configure_logger_info_level_or_higher():
+    logger = logging.getLogger(__name__)
+    result = configure_logger(logger, log_level_string="info")
+    assert logger.getEffectiveLevel() == 20  # noqa: PLR2004
+    assert result == "Logger 'tests.test_config' configured with level=INFO"
+
+
+def test_configure_logger_debug_level_or_lower():
+    logger = logging.getLogger(__name__)
+    result = configure_logger(logger, log_level_string="DEBUG")
+    assert logger.getEffectiveLevel() == 10  # noqa: PLR2004
+    assert result == "Logger 'tests.test_config' configured with level=DEBUG"
 
 
 def test_configure_sentry_no_env_variable(monkeypatch):
@@ -17,3 +41,20 @@ def test_configure_sentry_env_variable_is_dsn(monkeypatch):
     monkeypatch.setenv("SENTRY_DSN", "https://1234567890@00000.ingest.sentry.io/123456")
     result = configure_sentry()
     assert result == "Sentry DSN found, exceptions will be sent to Sentry with env=test"
+
+
+def test_load_config_values_success():
+    config_values = load_config_values()
+    assert config_values == {
+        "FEED_TYPE": "test_feed_type",
+        "LOG_LEVEL": "INFO",
+        "SENTRY_DSN": "test_sentry_dsn",
+        "SNS_TOPIC": "test_sns_topic",
+        "WORKSPACE": "test",
+        "CONNECTION_STRING": "sqlite://",
+        "SYMPLECTIC_FTP_PATH": "/people.xml",
+        "SYMPLECTIC_FTP_HOST": "localhost",
+        "SYMPLECTIC_FTP_PORT": "test_symplectic_ftp_port",
+        "SYMPLECTIC_FTP_USER": "user",
+        "SYMPLECTIC_FTP_PASS": "pass",
+    }


### PR DESCRIPTION
#### What does this PR do?
Refactor method for loading configurations to simplify code and make it consistent with the team’s more recent practices.

#### Helpful background context
The CLI command is updated to use settings loaded from environment variables (see [IN-881](https://mitlibraries.atlassian.net/browse/IN-882?focusedCommentId=107085) for complete set of environment variables) rather than relying on CLI arguments specified in the ECS task definition. This results in the deprecation of all options (except for `sns_topic`) that were previously accepted as arguments to the CLI command.

Deprecation of the `--ftp` option also means the application is set up only to upload the XML file to the FTP server. Previously, the application included an option to write outputs from the run to an output file, however, this method was never used.

#### How can a reviewer manually see the effects of these changes?
1. Clone the repo.
2. Check into this branch `IN-884-refactor-config-loading`.
3. Create a new virtual environment.
4. Install dependencies: `make install`
5. Run linters: `make lint`
6. Run test: `make test`


#### Includes new or updated dependencies?
NO

#### Developer
- [ ] README is updated to reflect all changes as needed
- [ ] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated to reflect all changes or is not needed
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
