### PR TITLE
IN-887 Refactor Carbon app to use new Symplectic FTP parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,5 +97,5 @@ dist-stage:
 	docker push $(ECR_URL_STAGE):latest
 	docker push $(ECR_URL_STAGE):`git describe --always`
 
-database-connection-test-stage: # use after the Data Warehouse password is changed every year to confirm that the new password works.
-	aws ecs run-task --cluster carbon-ecs-stage --task-definition carbon-ecs-stage-people --launch-type="FARGATE" --region us-east-1 --network-configuration '{"awsvpcConfiguration": {"subnets": ["subnet-05df31ac28dd1a4b0","subnet-04cfa272d4f41dc8a"], "securityGroups": ["sg-0f11e2619db7da196"],"assignPublicIp": "DISABLED"}}' --overrides '{"containerOverrides": [ {"name": "carbon-ecs-stage", "command": ["--database_connection_test"]}]}'
+run-connection-tests-stage: # use after the Data Warehouse password is changed every year to confirm that the new password works.
+	aws ecs run-task --cluster carbon-ecs-stage --task-definition carbon-ecs-stage-people --launch-type="FARGATE" --region us-east-1 --network-configuration '{"awsvpcConfiguration": {"subnets": ["subnet-05df31ac28dd1a4b0","subnet-04cfa272d4f41dc8a"], "securityGroups": ["sg-0f11e2619db7da196"],"assignPublicIp": "DISABLED"}}' --overrides '{"containerOverrides": [ {"name": "carbon-ecs-stage", "command": ["--run_connection_tests"]}]}'

--- a/carbon/app.py
+++ b/carbon/app.py
@@ -481,6 +481,32 @@ class FTPFeeder:
             )
             PipeWriter(out=fp_w).pipe(ftp_rdr).write(feed_type)
 
+    def run_connection_test(self) -> None:
+        """Test connection to the Symplectic Elements FTP server.
+
+        Verify that the provided FTP credentials can be used
+        to successfully connect to the Symplectic Elements FTP server.
+        """
+        logger.info("Testing connection to the Symplectic Elements FTP server")
+        try:
+            ftps = CarbonCopyFTPS(context=self.ssl_ctx, timeout=30)
+            ftps.connect(
+                self.config["SYMPLECTIC_FTP_HOST"],
+                int(self.config["SYMPLECTIC_FTP_PORT"]),
+            )
+            ftps.login(
+                user=self.config["SYMPLECTIC_FTP_USER"],
+                passwd=self.config["SYMPLECTIC_FTP_PASS"],
+            )
+        except Exception as error:
+            error_message = (
+                f"Failed to connect to the Symplectic Elements FTP server: {error}"
+            )
+            logger.exception(error_message)
+        else:
+            logger.info("Successfully connected to the Symplectic Elements FTP server")
+            ftps.quit()
+
 
 def sns_log(
     config_values: dict[str, Any], status: str, error: Exception | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ def _app_init():
 
 
 @pytest.fixture(autouse=True)
-def _test_env():
+def _test_env(ftp_server):
+    ftp_socket, ftp_directory = ftp_server
     os.environ["FEED_TYPE"] = "test_feed_type"
     os.environ["LOG_LEVEL"] = "INFO"
     os.environ["SENTRY_DSN"] = "None"
@@ -34,7 +35,7 @@ def _test_env():
     os.environ["SYMPLECTIC_FTP_PATH"] = "/people.xml"
     os.environ["SYMPLECTIC_FTP_JSON"] = (
         '{"SYMPLECTIC_FTP_HOST": "localhost", '
-        '"SYMPLECTIC_FTP_PORT": "test_symplectic_ftp_port",'
+        f'"SYMPLECTIC_FTP_PORT": "{ftp_socket[1]}",'
         '"SYMPLECTIC_FTP_USER": "user", '
         '"SYMPLECTIC_FTP_PASS": "pass"}'
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,24 +23,12 @@ def runner():
 def test_people_returns_people(
     feed_type,
     symplectic_ftp_path,
-    monkeypatch,
     runner,
     people_data,
     ftp_server,
     stubbed_sns_client,
 ):
     ftp_socket, ftp_directory = ftp_server
-    os.environ["FEED_TYPE"] = feed_type
-    os.environ["SYMPLECTIC_FTP_PATH"] = symplectic_ftp_path
-    monkeypatch.setenv(
-        "SYMPLECTIC_FTP_JSON",
-        (
-            '{"SYMPLECTIC_FTP_HOST": "localhost", '
-            f'"SYMPLECTIC_FTP_PORT": "{ftp_socket[1]}",'
-            '"SYMPLECTIC_FTP_USER": "user", '
-            '"SYMPLECTIC_FTP_PASS": "pass"}'
-        ),
-    )
 
     with patch("boto3.client") as mocked_boto_client:
         mocked_boto_client.return_value = stubbed_sns_client
@@ -64,24 +52,12 @@ def test_people_returns_people(
 def test_articles_returns_articles(
     feed_type,
     symplectic_ftp_path,
-    monkeypatch,
     runner,
     articles_data,
     ftp_server,
     stubbed_sns_client,
 ):
     ftp_socket, ftp_directory = ftp_server
-    os.environ["FEED_TYPE"] = feed_type
-    os.environ["SYMPLECTIC_FTP_PATH"] = symplectic_ftp_path
-    monkeypatch.setenv(
-        "SYMPLECTIC_FTP_JSON",
-        (
-            '{"SYMPLECTIC_FTP_HOST": "localhost", '
-            f'"SYMPLECTIC_FTP_PORT": "{ftp_socket[1]}",'
-            '"SYMPLECTIC_FTP_USER": "user", '
-            '"SYMPLECTIC_FTP_PASS": "pass"}'
-        ),
-    )
 
     with patch("boto3.client") as mocked_boto_client:
         mocked_boto_client.return_value = stubbed_sns_client
@@ -111,8 +87,7 @@ def test_file_is_ftped(
     stubbed_sns_client,
 ):
     ftp_socket, ftp_directory = ftp_server
-    os.environ["FEED_TYPE"] = feed_type
-    os.environ["SYMPLECTIC_FTP_PATH"] = symplectic_ftp_path
+
     monkeypatch.setenv(
         "SYMPLECTIC_FTP_JSON",
         (
@@ -131,17 +106,7 @@ def test_file_is_ftped(
     assert os.path.exists(os.path.join(ftp_directory, "people.xml"))
 
 
-def test_cli_connection_tests_success(caplog, ftp_server, monkeypatch, runner):
-    ftp_socket, _ = ftp_server
-    monkeypatch.setenv(
-        "SYMPLECTIC_FTP_JSON",
-        (
-            '{"SYMPLECTIC_FTP_HOST": "localhost", '
-            f'"SYMPLECTIC_FTP_PORT": "{ftp_socket[1]}",'
-            '"SYMPLECTIC_FTP_USER": "user", '
-            '"SYMPLECTIC_FTP_PASS": "pass"}'
-        ),
-    )
+def test_cli_connection_tests_success(caplog, runner):
     result = runner.invoke(main, ["--run_connection_tests"])
     assert result.exit_code == 0
     assert "Successfully connected to the Data Warehouse" in caplog.text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,16 +45,4 @@ def test_configure_sentry_env_variable_is_dsn(monkeypatch):
 
 def test_load_config_values_success():
     config_values = load_config_values()
-    assert config_values == {
-        "FEED_TYPE": "test_feed_type",
-        "LOG_LEVEL": "INFO",
-        "SENTRY_DSN": "None",
-        "SNS_TOPIC": "arn:aws:sns:us-east-1:123456789012:test_sns_topic",
-        "WORKSPACE": "test",
-        "CONNECTION_STRING": "sqlite://",
-        "SYMPLECTIC_FTP_PATH": "/people.xml",
-        "SYMPLECTIC_FTP_HOST": "localhost",
-        "SYMPLECTIC_FTP_PORT": "test_symplectic_ftp_port",
-        "SYMPLECTIC_FTP_USER": "user",
-        "SYMPLECTIC_FTP_PASS": "pass",
-    }
+    assert config_values["FEED_TYPE"] == "test_feed_type"


### PR DESCRIPTION
#### What does this PR do?
Refactor Carbon app to use new Symplectic FTP SSM parameters

#### Helpful background context
Prior to these updates, the Carbon app relied on three (3) separate SSM parameters 
related to Symplectic Elements FTP credentials: 
* `/tfvars/apps-vars/carbon/ftp-host`;
* `/tfvars/apps-vars/carbon/ftp-pass`; and
* `/tfvars/apps-vars/carbon/ftp-user`

To simplify management of FTP credentials, FTP credentials are now stored
in a one (1) SSM parameter that consists of a single JSON formatted string.

Eventually, the deprecated SSM parameters should be removed to avoid confusion.

Also, @ehanson8 , I added a note about the minor issue related to the CLI test `test_cli_connection_tests_fail` in the `README`; figured it'd be easier to keep track off than the commit!

#### How can a reviewer manually see the effects of these changes?

1. Review Cloudwatch [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F669818c174354b439ed592163a93cb8f) for **successful connection tests with the Data Warehouse and Symplectic Elements FTP server**.
2. Review Cloudwatch [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F043c979a7081476f97e86986d0423c2a) for a **failed connection test with the Data Warehouse**.
3.  Review Cloudwatch [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F69a7e2fec8a04d6792cb1212fa258d0e) for a **failed connection test with the Symplectic Elements FTP server**.

If you would like to run it yourself: 

1. Clone the repo.
2. Check into this branch `IN-887-use-new-symplectic-ftp-params`.
3. Create a new virtual environment.
4. Install dependencies: `make install`.
5. Run linters: `make lint`.
6. Run test: `make run-connection-tests-stage`.


#### Includes new or updated dependencies?
NO

#### Developer
- [x] README is updated to reflect all changes as needed
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated to reflect all changes or is not needed
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
