### PR TITLE
IN-906 Include creation of SQLAlchemy engine in main workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Carbon is a tool for generating a feed of people that can be loaded into Symplec
 
 The Data Warehouse runs on an older version of Oracle that necessitates the `thick` mode of python-oracledb, which requires the Oracle Instant Client Library (this app was developed with version 21.9.0.0.0). The test suite uses SQLite, so you can develop and test without connecting to the Data Warehouse.
 
-**Note:** One of the unit tests (`test_cli_connection_tests_fail`) checks that an error message is returned if the app fails to connect to the Data Warehouse. With the current structure of the application, which relies on a single SQLAlchemy engine that is created in `db.py`, this test must be run at the end because it modifies the content of the engine that would cause other tests to fail. This "bug" (not technically a breaking change) will be addressed in later efforts to enhance the Carbon application.
-
 ### With Docker
 
 **Note:** As of this writing, the Apple M1 Macs cannot run Oracle Instant Client, so Docker is the only option for development on those machines.

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -5,7 +5,7 @@ import click
 
 from carbon.app import DatabaseToFtpPipe
 from carbon.config import configure_logger, configure_sentry, load_config_values
-from carbon.database import engine
+from carbon.database import DatabaseEngine
 from carbon.helpers import sns_log
 
 logger = logging.getLogger(__name__)
@@ -43,12 +43,14 @@ def main(*, run_connection_tests: bool) -> None:
         config_values["WORKSPACE"],
     )
 
+    engine = DatabaseEngine()
+
     # test connection to the Data Warehouse
     engine.configure(config_values["CONNECTION_STRING"], thick_mode=True)
     engine.run_connection_test()
 
     # test connection to the Symplectic Elements FTP server
-    pipe = DatabaseToFtpPipe(config=config_values)
+    pipe = DatabaseToFtpPipe(config=config_values, engine=engine)
     pipe.run_connection_test()
 
     if not run_connection_tests:

--- a/carbon/database.py
+++ b/carbon/database.py
@@ -124,7 +124,3 @@ class DatabaseEngine:
                 version,  # type: ignore[union-attr]
             )
             connection.close()
-
-
-# create the database engine
-engine = DatabaseEngine()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,45 +27,45 @@ qualified_tag_name = ET.QName(symplectic_elements_namespace, tag="records")
 nsmap = {None: symplectic_elements_namespace}
 
 
-def test_people_generates_people():
-    people_records = list(people())
+def test_people_generates_people(functional_engine):
+    people_records = list(people(engine=functional_engine))
     person = people_records[0]
     assert person["KRB_NAME_UPPERCASE"] == "FOOBAR"
     person = people_records[1]
     assert person["KRB_NAME_UPPERCASE"] == "THOR"
 
 
-def test_people_adds_orcids():
-    people_records = list(people())
+def test_people_adds_orcids(functional_engine):
+    people_records = list(people(engine=functional_engine))
     assert people_records[0]["ORCID"] == "http://example.com/1"
 
 
-def test_people_excludes_records_without_email():
-    people_records = list(people())
+def test_people_excludes_records_without_email(functional_engine):
+    people_records = list(people(engine=functional_engine))
     people_without_emails = [
         person for person in people_records if person["EMAIL_ADDRESS"] is None
     ]
     assert len(people_without_emails) == 0
 
 
-def test_people_excludes_records_without_last_name():
-    people_records = list(people())
+def test_people_excludes_records_without_last_name(functional_engine):
+    people_records = list(people(engine=functional_engine))
     people_without_last_names = [
         person for person in people_records if person["LAST_NAME"] is None
     ]
     assert len(people_without_last_names) == 0
 
 
-def test_people_excludes_records_without_kerberos():
-    people_records = list(people())
+def test_people_excludes_records_without_kerberos(functional_engine):
+    people_records = list(people(engine=functional_engine))
     people_without_kerberos = [
         person for person in people_records if person["KRB_NAME_UPPERCASE"] is None
     ]
     assert len(people_without_kerberos) == 0
 
 
-def test_people_excludes_records_without_mit_id():
-    people_records = list(people())
+def test_people_excludes_records_without_mit_id(functional_engine):
+    people_records = list(people(engine=functional_engine))
     people_without_mit_id = [
         person for person in people_records if person["MIT_ID"] is None
     ]
@@ -94,9 +94,9 @@ def test_add_child_adds_child_element(people_element_maker):
     assert ET.tostring(element) == ET.tostring(xml)
 
 
-def test_writer_writes_person_feed():
+def test_writer_writes_person_feed(functional_engine):
     output_file = BytesIO()
-    writer = Writer(output_file)
+    writer = Writer(functional_engine, output_file)
     writer.write("people")
     xml = ET.XML(output_file.getvalue())
     xp = xml.xpath(
@@ -106,13 +106,15 @@ def test_writer_writes_person_feed():
     assert xp[1].text == "Þorgerðr"
 
 
-def test_pipewriter_writes_person_feed(reader):
+def test_pipewriter_writes_person_feed(reader, functional_engine):
     read_file, write_file = os.pipe()
     with open(read_file, "rb") as buffered_reader, open(
         write_file, "wb"
     ) as buffered_writer:
         file = reader(buffered_reader)
-        writer = PipeWriter(input_file=buffered_writer, ftp_output_file=file)
+        writer = PipeWriter(
+            engine=functional_engine, input_file=buffered_writer, ftp_output_file=file
+        )
         writer.write("people")
     people_element = ET.XML(file.data)
     people_first_names_xpath = people_element.xpath(
@@ -182,8 +184,8 @@ def test_group_name_adds_non_faculty():
     assert get_group_name("FOOBAR", "COAC") == "FOOBAR Non-faculty"
 
 
-def test_articles_generates_articles():
-    articles_records = list(articles())
+def test_articles_generates_articles(functional_engine):
+    articles_records = list(articles(engine=functional_engine))
     assert "Yawning Abyss of Chaos" in articles_records[0]["ARTICLE_TITLE"]
 
 
@@ -196,8 +198,8 @@ def test_article_feed_adds_article(articles_records, articles_element):
     )
 
 
-def test_articles_skips_articles_without_required_fields():
-    articles_records = list(articles())
+def test_articles_skips_articles_without_required_fields(functional_engine):
+    articles_records = list(articles(engine=functional_engine))
     assert len(articles_records) == 1
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 from lxml import etree as ET
 
 from carbon.cli import main
-from carbon.database import engine
 
 
 @pytest.fixture
@@ -23,15 +22,19 @@ def runner():
 def test_people_returns_people(
     feed_type,
     symplectic_ftp_path,
-    runner,
-    people_element,
     ftp_server,
+    functional_engine,
+    people_element,
+    runner,
     stubbed_sns_client,
 ):
     _, ftp_directory = ftp_server
 
-    with patch("boto3.client") as mocked_boto_client:
+    with patch("boto3.client") as mocked_boto_client, patch(
+        "carbon.cli.DatabaseEngine"
+    ) as mocked_engine:
         mocked_boto_client.return_value = stubbed_sns_client
+        mocked_engine.return_value = functional_engine
         result = runner.invoke(main)
         assert result.exit_code == 0
 
@@ -52,15 +55,19 @@ def test_people_returns_people(
 def test_articles_returns_articles(
     feed_type,
     symplectic_ftp_path,
-    runner,
     articles_element,
     ftp_server,
+    functional_engine,
+    runner,
     stubbed_sns_client,
 ):
     _, ftp_directory = ftp_server
 
-    with patch("boto3.client") as mocked_boto_client:
+    with patch("boto3.client") as mocked_boto_client, patch(
+        "carbon.cli.DatabaseEngine"
+    ) as mocked_engine:
         mocked_boto_client.return_value = stubbed_sns_client
+        mocked_engine.return_value = functional_engine
         result = runner.invoke(main)
         assert result.exit_code == 0
 
@@ -81,9 +88,10 @@ def test_articles_returns_articles(
 def test_file_is_ftped(
     feed_type,
     symplectic_ftp_path,
+    ftp_server,
+    functional_engine,
     monkeypatch,
     runner,
-    ftp_server,
     stubbed_sns_client,
 ):
     ftp_socket, ftp_directory = ftp_server
@@ -98,28 +106,31 @@ def test_file_is_ftped(
         ),
     )
 
-    with patch("boto3.client") as mocked_boto_client:
+    with patch("boto3.client") as mocked_boto_client, patch(
+        "carbon.cli.DatabaseEngine"
+    ) as mocked_engine:
         mocked_boto_client.return_value = stubbed_sns_client
+        mocked_engine.return_value = functional_engine
         result = runner.invoke(main)
         assert result.exit_code == 0
 
     assert os.path.exists(os.path.join(ftp_directory, "people.xml"))
 
 
-def test_cli_connection_tests_success(caplog, runner):
-    result = runner.invoke(main, ["--run_connection_tests"])
-    assert result.exit_code == 0
+def test_cli_connection_tests_success(caplog, functional_engine, runner):
+    with patch("carbon.cli.DatabaseEngine") as mocked_engine:
+        mocked_engine.return_value = functional_engine
+        result = runner.invoke(main, ["--run_connection_tests"])
+        assert result.exit_code == 0
+
     assert "Successfully connected to the Data Warehouse" in caplog.text
     assert "Successfully connected to the Symplectic Elements FTP server" in caplog.text
 
 
-def test_cli_connection_tests_fail(caplog, ftp_server, monkeypatch, runner):
+def test_cli_connection_tests_fail(
+    caplog, ftp_server, monkeypatch, nonfunctional_engine, runner
+):
     ftp_socket, _ = ftp_server
-
-    # override engine from pytest fixture
-    # configure with connection string that will error out with engine.connect()
-    engine._engine = None  # noqa: SLF001
-    engine.configure(connection_string="sqlite:///nonexistent_directory/bad.db")
 
     monkeypatch.setenv(
         "SYMPLECTIC_FTP_JSON",
@@ -130,7 +141,10 @@ def test_cli_connection_tests_fail(caplog, ftp_server, monkeypatch, runner):
             '"SYMPLECTIC_FTP_PASS": "invalid_password"}'
         ),
     )
-    result = runner.invoke(main, ["--run_connection_tests"])
-    assert result.exit_code == 0
+    with patch("carbon.cli.DatabaseEngine") as mocked_engine:
+        mocked_engine.return_value = nonfunctional_engine
+        result = runner.invoke(main, ["--run_connection_tests"])
+        assert result.exit_code == 0
+
     assert "Failed to connect to the Data Warehouse" in caplog.text
     assert "Failed to connect to the Symplectic Elements FTP server" in caplog.text


### PR DESCRIPTION
#### What does this PR do?
Restructure the application codebase to include the creation of the SQLAlchemy engine as part of the main workflow.

#### How can a reviewer manually see the effects of these changes?

1. Clone the repo.
2. Check into this branch `IN-906-include-engine-creation-in-main`.
3. Create a new virtual environment.
4. Install dependencies: `make install`.
5. Run linters: `make lint`.
6. Run test: `make test`.

All tests should pass as a result of making updates to necessary classes and methods in `app.py` to accept an instance of `DatabaseEngine`. 

#### Includes new or updated dependencies?
NO

#### Developer
- [x] README is updated to reflect all changes as needed
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated to reflect all changes or is not needed
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
