### PR TITLE
IN-923 Raise exceptions for failed connection tests / IN-925 Add Makefile commands to run Carbon feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,10 @@ run-connection-tests-with-docker: # run connection tests from local docker insta
 	docker run -v ./.env:/.env carbon-dev --run_connection_tests
 
 run-connection-tests-with-ecs-stage: # use after the Data Warehouse password is changed every year to confirm that the new password works
-	aws ecs run-task --cluster carbon-ecs-stage --task-definition carbon-ecs-stage-people --launch-type="FARGATE" --region us-east-1 --network-configuration '{"awsvpcConfiguration": {"subnets": ["subnet-05df31ac28dd1a4b0","subnet-04cfa272d4f41dc8a"], "securityGroups": ["sg-0f11e2619db7da196"],"assignPublicIp": "DISABLED"}}' --overrides '{"containerOverrides": [ {"name": "carbon-ecs-stage", "command": ["--run_connection_tests"]}]}'
+	aws ecs run-task --cluster carbon-ecs-stage --task-definition carbon-ecs-stage-people --launch-type="FARGATE" --region us-east-1 --network-configuration '{"awsvpcConfiguration": {"subnets": ["subnet-05df31ac28dd1a4b0","subnet-04cfa272d4f41dc8a"], "securityGroups": ["sg-0f11e2619db7da196"],"assignPublicIp": "DISABLED"}}' --overrides '{"containerOverrides": [ {"name": "carbon-ecs-stage", "command": ["--run_connection_tests", "--ignore_sns_logging"]}]}'
+
+run-articles-feed-with-ecs-stage: # run 'articles' feed
+	aws ecs run-task --cluster carbon-ecs-stage --task-definition carbon-ecs-stage-articles --launch-type="FARGATE" --region us-east-1 --network-configuration '{"awsvpcConfiguration": {"subnets": ["subnet-05df31ac28dd1a4b0","subnet-04cfa272d4f41dc8a"], "securityGroups": ["sg-0f11e2619db7da196"],"assignPublicIp": "DISABLED"}}' --overrides '{"containerOverrides": [ {"name": "carbon-ecs-stage", "command": ["--ignore_sns_logging"]}]}'
+
+run-people-feed-with-ecs-stage: # run 'people' feed
+	aws ecs run-task --cluster carbon-ecs-stage --task-definition carbon-ecs-stage-people --launch-type="FARGATE" --region us-east-1 --network-configuration '{"awsvpcConfiguration": {"subnets": ["subnet-05df31ac28dd1a4b0","subnet-04cfa272d4f41dc8a"], "securityGroups": ["sg-0f11e2619db7da196"],"assignPublicIp": "DISABLED"}}' --overrides '{"containerOverrides": [ {"name": "carbon-ecs-stage", "command": ["--ignore_sns_logging"]}]}'

--- a/carbon/app.py
+++ b/carbon/app.py
@@ -244,6 +244,7 @@ class DatabaseToFtpPipe:
                 f"Failed to connect to the Symplectic Elements FTP server: {error}"
             )
             logger.exception(error_message)
+            raise
         else:
             logger.info("Successfully connected to the Symplectic Elements FTP server")
             ftps.quit()

--- a/carbon/database.py
+++ b/carbon/database.py
@@ -114,6 +114,7 @@ class DatabaseEngine:
         except Exception as error:
             error_message = f"Failed to connect to the Data Warehouse: {error}"
             logger.exception(error_message)
+            raise
         else:
             dbapi_connection = connection.connection
             version = (


### PR DESCRIPTION
#### What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
Why are we making these changes? Is there more work to be done to fully
achieve these goals?

#### How can a reviewer manually see the effects of these changes?

For **IN-923 Raise exceptions for failed connection tests**:
1. Check the CloudWatch for successful connection tests: [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F93b0a7baafbd41c4936a379277698054)
   * To produce this log, I ran the Docker image with the code as-is, which should run successfully as it uses the appropriate credentials and  does not include a forced `ZeroDivisionError`.
<img width="1402" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/82742ac0-58bf-4f87-8ce2-53377f8a7df4">


2. Check the CloudWatch log for failed connection test for Data Warehouse (tests [lines 114-117](https://github.com/MITLibraries/carbon/blob/IN-923-925-raise-exceptions-and-add-make-commands/carbon/database.py#L114) of `database.py`): 
   * To produce this log, I created a temporary Docker image where I added `1 / 0` after line 113 of `carbon.database.DatabaseEngine.run_connection_test()` to force a raised exception: [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F4b401166a75d47b99994fb1afb76f1d1) 
<img width="1410" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/dace4a94-7e44-48e0-bb00-600d309048b5">


3. Check the CloudWatch log for failed connection test for Symplectic Elements FTP server (tests [lines 242-247](https://github.com/MITLibraries/carbon/blob/IN-923-925-raise-exceptions-and-add-make-commands/carbon/app.py#L242) of `app.py`): 
   * To produce this log, I created a temporary Docker image where I added `1 / 0` after line 241 of `carbon.app.DatabaseToFtpPipe.run_connection_test()` to force a raised exception: [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252Faa9a0689aaf545918ac9f7ddbcb01e59)
<img width="1407" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/2ac7b2c2-67f7-451e-9c8f-0021e75d1dc1">

---

For **IN-925 Add Makefile commands for running 'people' and 'articles' feed as an ECS task**:

**Check `'people'` feed run:** 
1. Check the CloudWatch log for successful 'people' feed run: [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252Fec14e6c9ca894578a0fd826d86b92795)
   * **Note:** You may see an error message (shown below), but if you check the Elements FTP server, you should see that an XML file still gets uploaded. 
2. See screenshot below showing that `HRDataFeed.xml` is uploaded to the Elements FTP server (with today's date 9/20):
   <img width="466" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/bbd6b418-41ff-444c-85f4-815eaf960076">

**Check `'articles'` feed run:**

1. Check the CloudWatch log for successful 'articles' feed run: [log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F9e2ff6b746e74e52b6c9b6ada7b17659)

2. See screenshot below showing that `AA_articles.xml` is uploaded to the Elements FTP server (with today's date 9/20): 
   <img width="467" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/7120a15e-3c22-47e1-b700-0d625582597a">

**Note:** If you are interested in accessing the Elements FTP server, please refer to the instructions in this Confluence document: [Carbon | Developer Guide | How to access files uploaded to the Elements FTP server](https://mitlibraries.atlassian.net/wiki/spaces/~712020c6fcb37f39c94e54a6bfd09607f29eb4/pages/3455811597/Carbon+A+tool+for+loading+data+into+Symplectic+Elements#How-to-access-files-uploaded-to-the-Elements-FTP-server%3F).

---

#### Includes new or updated dependencies?
NO

#### Developer
- [x] README is updated to reflect all changes as needed
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated to reflect all changes or is not needed
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
