### PR TITLE
In 924 fix ftp file transfer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The test suite uses SQLite, so you can develop and test without connecting to th
       **Note**: As of this writing, Apple M1 Macs cannot run Oracle Instant Client.
    * If you are on a machine that can run Oracle Instant Client, follow the steps outlined in [Without Docker](#without-docker).
 
+The data retrieved by the Carbon application contains personally identifiable information (PII), so downloading the files is not recommended. However, if examining the files created by Carbon is **absolutely necessary** for testing purposes, this can be done on your local machine via a Docker container. For more information, please refer to the Confluence document: [How to download files from an application that connects to the Data Warehouse](https://mitlibraries.atlassian.net/wiki/spaces/~712020c6fcb37f39c94e54a6bfd09607f29eb4/pages/3469443097/Running+applications+in+a+local+Docker+Container).
+
+**Note:** Any downloaded files or `.env` files must be **immediately deleted** after testing is complete.
+
 #### With Docker
 
 1. Run `make dependencies` to download the Oracle Instant Client from S3.
@@ -46,6 +50,7 @@ The test suite uses SQLite, so you can develop and test without connecting to th
 3. Run `make publish-dev` to push the Docker container image to ECR for the `Dev1` environment. 
 
 4. Run any `make` commands for testing the application. In the Makefile, the names of relevant make commands will contain the suffix '-with-docker'.
+
 
 #### Without Docker
 

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -85,7 +85,9 @@ def main(*, output_file: IO, run_connection_tests: bool, use_sns_logging: bool) 
         pipe.run_connection_test()
 
     if not run_connection_tests:
-        logger.info("Carbon run has started.")
+        logger.info(
+            "Carbon run for the '%s' feed has started.", config_values["FEED_TYPE"]
+        )
         if use_sns_logging:
             sns_log(config_values=config_values, status="start")
         try:

--- a/carbon/feed.py
+++ b/carbon/feed.py
@@ -35,7 +35,7 @@ class BaseXmlFeed(ABC):
 
     root_element_name: str = ""
     query: Select = select()
-    record_count: int = 0
+    processed_record_count: int = 0
 
     def __init__(self, engine: DatabaseEngine, output_file: IO):
         self.engine = engine
@@ -52,7 +52,6 @@ class BaseXmlFeed(ABC):
         with closing(self.engine().connect()) as connection:
             result = connection.execute(self.query)
             for row in result:
-                self.record_count += 1
                 yield dict(zip(result.keys(), row, strict=True))
 
     @abstractmethod
@@ -101,6 +100,7 @@ class BaseXmlFeed(ABC):
                 for record in self.records:
                     element = self._add_element(record)
                     xml_file.write(element)
+                    self.processed_record_count += 1
 
 
 class ArticlesXmlFeed(BaseXmlFeed):


### PR DESCRIPTION
## What does this PR do?
The work in this PR is to investigate the 'errors' with the `ftplib.storbinary` method that are logged for the 'people' feed (described in [this Github issue](https://github.com/MITLibraries/carbon/issues/112)) and the 'articles' feed (described in [this Jira ticket](https://mitlibraries.atlassian.net/browse/IN-878)]. 

Here are some key learnings from this effort: 

* **Articles feed**
   * It seems the error may be due to the FTP connection 'hanging' because as `storbinary()` is running (it takes >5 minutes for the Article, it is 'blocking' any other commands from being run on the FTP server. This leads to an 'idle' FTP connection. As described in [this thread](https://stackoverflow.com/questions/19692739/python-ftplib-hangs-at-end-of-transfer): 
      > Either your client is timing out the control channel, or the server is. So, when you try to hang up with ftp.quit(), it will either hang forever or raise an exception.
   * Extending `CarbonFtpsTls.timeout` does not seem to have an effect. It just delays the logging of the `TimeoutError`.
   * There doesn't appear to be a straightforward way to keep the connection alive, but **the `TimeoutError` has not shown to be an issue and will still result in an XML file uploaded to the Elements FTP server.**

* **People feed**
   * The error goes away when we use the default `FTPS_TLS.storbinary()` method. 
   
## Helpful background context
While looking into this issue, @ghukill came across [this thread](https://stackoverflow.com/questions/31851998/ftplib-file-creation-very-slow-sslerror-the-read-operation-timed-out/70830916#70830916), which we assume is the reason for previously overwriting the `storbinary()` command. However, as stated previously, using the default `FTPS_TLS.storbinary()` method results in the same XML file while avoiding the error for the 'people' feed.

## How can a reviewer manually see the effects of these changes?

### Compare logs from different code iterations, and verify that latest code enables successful Carbon runs with improved logging

Produced by code in `main`: 
* [People feed](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F1e8bcbbf10f54383a9b121d5ddb6ac4d)
   <img width="961" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/3923921f-58ef-4056-93e8-130ba8e45108">

* [Articles feed](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252Ff86c0f07376c44afb10240aec765a0b5)
   <img width="965" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/4e8b88a2-3558-4664-bce3-d3562ba51d30">
 
Produced by Commenting out CarbonFtpsTls.storbinary():

* [ People feed](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F9ccc631c3bf44ade928791bcf89bae2f)
   <img width="1055" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/27fd9de6-9dad-41bf-bedb-56d2fad88305">

* [Articles feed](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252Fdf22551b1aa24bdaa133dbda3db7109f)
   <img width="963" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/d575f22e-ffa7-4d33-a103-d39dae4ec29b">

Code in this branch
* [People feed](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252Fa9ba49b123c94570b2a1357da3c7530b)
   <img width="1080" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/45e95d81-8438-4465-a0a8-77738b1e7fa8">

* [Articles feed](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/carbon-ecs-stage/log-events/carbon$252Fcarbon-ecs-stage$252F07638013d25d417f8c4e95d795c9aee0)
   <img width="1340" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/b7e2e1d4-9074-4930-94e5-c23d06ab53f5">


### Compare XML files produced with latest code (excludes custom `CarbonFtpsTls.storbinary` against XML files produced with current code in `main`)

1. A simple `diff` shows that comparing the pairs of files (original vs. latest) have the same bytes/characters.
<img width="635" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/658ee51f-c824-478d-91d7-5091efff4491">

2. Logs are the same when running original code vs. latest code. Note that the FTP-related errors do not appear because these tests involve running the application in a Docker container on a local machine. 
   * Latest
      <img width="1149" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/6e78510d-6bd3-4ead-8bd8-967ec850fc9d">
   * Original
      <img width="1144" alt="image" src="https://github.com/MITLibraries/carbon/assets/29102054/1cca1908-76d9-4ed6-bcdf-3d8943ad9109">

#### Includes new or updated dependencies?
NO

#### Developer
- [x] README is updated to reflect all changes as needed
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated to reflect all changes or is not needed
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
